### PR TITLE
Mark PHPUnit as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
   "require": {
     "php": ">=5.4",
     "ext-curl": "*",
-    "ext-json": "*",
-    "phpunit/phpunit": "^7.5"
+    "ext-json": "*"
   },
   "require-dev": {
-    "monolog/monolog": "^1.23"
+    "monolog/monolog": "^1.23",
+    "phpunit/phpunit": "^7.5"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
PHPUnit is not a runtime dependency of the library, which is not reflected correctly in composer config.