### PR TITLE
Add support for getPaymentStatus API method

### DIFF
--- a/src/SafeCharge/Api/Service/PaymentService.php
+++ b/src/SafeCharge/Api/Service/PaymentService.php
@@ -230,4 +230,24 @@ class PaymentService extends BaseService
 
         return $this->requestJson($params, 'voidTransaction.do');
     }
+
+    /**
+     * @param array $params
+     *
+     * @return mixed
+     * @throws \SafeCharge\Api\Exception\ConnectionException
+     * @throws \SafeCharge\Api\Exception\ResponseException
+     * @throws \SafeCharge\Api\Exception\ValidationException
+     * @link https://www.safecharge.com/docs/API/main/indexMain_v1_0.html?json#getPaymentStatus
+     */
+    public function getPaymentStatus(array $params)
+    {
+        $mandatoryFields = ['sessionToken'];
+
+        $params['webMasterId'] = RestClient::getClientName();
+
+        $this->validate($params, $mandatoryFields);
+
+        return $this->requestJson($params, 'getPaymentStatus.do');
+    }
 }


### PR DESCRIPTION
The PHP SDK is not keeping up with the REST API development and is missing some methods. This PR adds support for `getPaymentStatus.do`, which is necessary for the Web SDK flow.

Fixes #13 