### PR TITLE
A few changes

### DIFF
--- a/src/SafeCharge/Api/Config.php
+++ b/src/SafeCharge/Api/Config.php
@@ -17,7 +17,7 @@ class Config implements ConfigInterface
 
     protected $configData = [];
 
-    protected $allowedHashAlgorithms = ['sha256', 'md5'];
+    protected $allowedHashAlgorithms = ['sha256'];
 
     // allowed output
     protected $allowedOutput = ['array', 'json'];
@@ -245,5 +245,16 @@ class Config implements ConfigInterface
             return false;
         }
         return true;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isDebugMode()
+    {
+        if (isset($this->configData['debugMode']) && $this->configData['debugMode'] == true ) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/SafeCharge/Api/Service/BaseService.php
+++ b/src/SafeCharge/Api/Service/BaseService.php
@@ -53,6 +53,10 @@ class BaseService implements ServiceInterface
      */
     public function getSessionToken()
     {
+        if(!empty($this->sessionToken)) {
+            return $this->sessionToken;
+        }
+
         $mandatoryFields = ['merchantId', 'timeStamp', 'checksum'];
 
         $checksumParametersOrder = ['merchantId', 'merchantSiteId', 'clientRequestId', 'timeStamp', 'merchantSecretKey'];
@@ -144,9 +148,28 @@ class BaseService implements ServiceInterface
      */
     public function requestJson($params, $endpoint)
     {
+        $service = $this;
+        $client = $service->getClient();
+        $config = $client->getConfig();
         $curlClient = $this->client->getHttpClient();
+        $debug = $config->isDebugMode();
 
-        return $curlClient->requestJson($this, $this->apiUrl . $endpoint, $params);
+        $params['sourceApplication'] = Utils::getSourceApplication();
+        $params['webMasterId'] = Utils::getWebMasterID();
+
+        if($debug) {
+            echo "\nMethod: " . $endpoint . "\nRequest: ";
+            print_r($params);
+        }
+
+        $response = $curlClient->requestJson($this, $this->apiUrl . $endpoint, $params);
+
+        if($debug) {
+            echo "Response: ";
+            print_r($response);
+        }
+
+        return $response;
     }
 
     /**

--- a/src/SafeCharge/Api/Service/PaymentService.php
+++ b/src/SafeCharge/Api/Service/PaymentService.php
@@ -53,7 +53,9 @@ class PaymentService extends BaseService
         $params = $this->appendIpAddress($params);
 
         $params['checksum']     = Utils::calculateChecksum($params, $checksumParametersOrder, $this->client->getConfig()->getMerchantSecretKey(), $this->client->getConfig()->getHashAlgorithm());
-        $params['sessionToken'] = $this->getSessionToken();
+        if(!isset($params['sessionToken'])) {
+            $params['sessionToken'] = $this->getSessionToken();
+        }
 
         if (isset($params['relatedTransactionId'])) {
             unset($params['externalSchemeDetails']['transactionId']);
@@ -83,8 +85,9 @@ class PaymentService extends BaseService
         $params = $this->appendIpAddress($params);
 
         $params['checksum']     = Utils::calculateChecksum($params, $checksumParametersOrder, $this->client->getConfig()->getMerchantSecretKey(), $this->client->getConfig()->getHashAlgorithm());
-        $params['sessionToken'] = $this->getSessionToken();
-
+        if(!isset($params['sessionToken'])) {
+            $params['sessionToken'] = $this->getSessionToken();
+        }
 
         $this->validate($params, $mandatoryFields);
 
@@ -109,8 +112,9 @@ class PaymentService extends BaseService
         $params = $this->appendIpAddress($params);
 
         $params['checksum']     = Utils::calculateChecksum($params, $checksumParametersOrder, $this->client->getConfig()->getMerchantSecretKey(), $this->client->getConfig()->getHashAlgorithm());
-        $params['sessionToken'] = $this->getSessionToken();
-
+        if(!isset($params['sessionToken'])) {
+            $params['sessionToken'] = $this->getSessionToken();
+        }
 
         $this->validate($params, $mandatoryFields);
 
@@ -131,8 +135,9 @@ class PaymentService extends BaseService
 
         $params = $this->appendMerchantIdMerchantSiteIdTimeStamp($params);
 
-        $params['sessionToken'] = $this->getSessionToken();
-
+        if(!isset($params['sessionToken'])) {
+            $params['sessionToken'] = $this->getSessionToken();
+        }
         $this->validate($params, $mandatoryFields);
 
         return $this->requestJson($params, 'verify3d.do');
@@ -156,8 +161,9 @@ class PaymentService extends BaseService
         $params = $this->appendIpAddress($params);
 
         $params['checksum']     = Utils::calculateChecksum($params, $checksumParametersOrder, $this->client->getConfig()->getMerchantSecretKey(), $this->client->getConfig()->getHashAlgorithm());
-        $params['sessionToken'] = $this->getSessionToken();
-
+        if(!isset($params['sessionToken'])) {
+            $params['sessionToken'] = $this->getSessionToken();
+        }
 
         $this->validate($params, $mandatoryFields);
 
@@ -193,8 +199,6 @@ class PaymentService extends BaseService
             'timeStamp',
             'merchantSecretKey'
         ];
-
-        $params['webMasterId'] = RestClient::getClientName();
 
         $params = $this->appendMerchantIdMerchantSiteIdTimeStamp($params);
 
@@ -235,7 +239,6 @@ class PaymentService extends BaseService
             'merchantSecretKey'
         ];
 
-        $params['webMasterId'] = RestClient::getClientName();
 
         $params = $this->appendMerchantIdMerchantSiteIdTimeStamp($params);
 
@@ -274,8 +277,6 @@ class PaymentService extends BaseService
             'merchantSecretKey'
         ];
 
-        $params['webMasterId'] = RestClient::getClientName();
-
         $params = $this->appendMerchantIdMerchantSiteIdTimeStamp($params);
 
         $params['checksum'] = Utils::calculateChecksum($params, $checksumParametersOrder, $this->client->getConfig()->getMerchantSecretKey(), $this->client->getConfig()->getHashAlgorithm());
@@ -312,14 +313,37 @@ class PaymentService extends BaseService
      * @throws \SafeCharge\Api\Exception\ConnectionException
      * @throws \SafeCharge\Api\Exception\ResponseException
      * @throws \SafeCharge\Api\Exception\ValidationException
+     * @link https://www.safecharge.com/docs/API/main/indexMain_v1_0.html?json#accountCapture
+     */
+    public function accountCapture(array $params)
+    {
+        $mandatoryFields = ['sessionToken', 'merchantId', 'merchantSiteId', 'userTokenId', 'paymentMethod', 'currencyCode', 'countryCode'];
+
+        $params = $this->appendMerchantIdMerchantSiteIdTimeStamp($params);
+        if(!isset($params['sessionToken'])) {
+            $params['sessionToken'] = $this->getSessionToken();
+        }
+        $this->validate($params, $mandatoryFields);
+
+        return $this->requestJson($params, 'accountCapture.do');
+    }
+
+    /**
+     * @param array $params
+     *
+     * @return mixed
+     * @throws \SafeCharge\Api\Exception\ConnectionException
+     * @throws \SafeCharge\Api\Exception\ResponseException
+     * @throws \SafeCharge\Api\Exception\ValidationException
      */
     public function getCardDetails(array $params)
     {
         $mandatoryFields = ['sessionToken', 'merchantId', 'merchantSiteId', 'cardNumber'];
 
         $params = $this->appendMerchantIdMerchantSiteIdTimeStamp($params);
-        $params['sessionToken'] = $this->getSessionToken();
-
+        if(!isset($params['sessionToken'])) {
+            $params['sessionToken'] = $this->getSessionToken();
+        }
         $this->validate($params, $mandatoryFields);
 
         return $this->requestJson($params, 'getCardDetails.do');
@@ -338,8 +362,9 @@ class PaymentService extends BaseService
         $mandatoryFields = ['sessionToken', 'merchantId', 'merchantSiteId', 'fromCurrency'];
 
         $params = $this->appendMerchantIdMerchantSiteIdTimeStamp($params);
-        $params['sessionToken'] = $this->getSessionToken();
-
+        if(!isset($params['sessionToken'])) {
+            $params['sessionToken'] = $this->getSessionToken();
+        }
         $this->validate($params, $mandatoryFields);
 
         return $this->requestJson($params, 'getMcpRates.do');
@@ -358,8 +383,9 @@ class PaymentService extends BaseService
         $mandatoryFields = ['sessionToken', 'merchantId', 'merchantSiteId', 'clientRequestId', 'clientUniqueId', 'originalAmount', 'originalCurrency'];
 
         $params = $this->appendMerchantIdMerchantSiteIdTimeStamp($params);
-        $params['sessionToken'] = $this->getSessionToken();
-
+        if(!isset($params['sessionToken'])) {
+            $params['sessionToken'] = $this->getSessionToken();
+        }
         $this->validate($params, $mandatoryFields);
 
         return $this->requestJson($params, 'getDccDetails.do');

--- a/src/SafeCharge/Api/Service/Payments/CreditCard.php
+++ b/src/SafeCharge/Api/Service/Payments/CreditCard.php
@@ -58,7 +58,6 @@ class CreditCard extends BaseService
 
         $checksumParametersOrder = ['merchantId', 'merchantSiteId', 'clientRequestId', 'amount', 'currency', 'timeStamp', 'merchantSecretKey'];
 
-        $params['webMasterId'] = RestClient::getClientName();
 
         $params = $this->appendMerchantIdMerchantSiteIdTimeStamp($params);
 

--- a/src/SafeCharge/Api/Service/Payments/ThreeDsecure.php
+++ b/src/SafeCharge/Api/Service/Payments/ThreeDsecure.php
@@ -40,7 +40,6 @@ class ThreeDsecure extends BaseService
 
         $checksumParametersOrder = ['merchantId', 'merchantSiteId', 'clientRequestId', 'amount', 'currency', 'timeStamp', 'merchantSecretKey'];
 
-        $params['webMasterId'] = RestClient::getClientName();
 
         $params = $this->appendMerchantIdMerchantSiteIdTimeStamp($params);
 
@@ -67,8 +66,6 @@ class ThreeDsecure extends BaseService
         $mandatoryFields = ['sessionToken', 'merchantId', 'merchantSiteId', 'transactionType', 'currency', 'amount', 'items', 'timeStamp', 'checksum'];
 
         $checksumParametersOrder = ['merchantId', 'merchantSiteId', 'clientRequestId', 'amount', 'currency', 'timeStamp', 'merchantSecretKey'];
-
-        $params['webMasterId'] = RestClient::getClientName();
 
         $params = $this->appendMerchantIdMerchantSiteIdTimeStamp($params);
 

--- a/src/SafeCharge/Api/Utils.php
+++ b/src/SafeCharge/Api/Utils.php
@@ -12,7 +12,7 @@ class Utils
      * @param $params array - parameters
      * @param $checksumParamsOrder array - array with parameter order for checksum calculation
      * @param $merchantSecretId - Merchant Site ID
-     * @param string $algo - algorithm (sha256, md5)
+     * @param string $algo - algorithm (sha256)
      *
      * @return string - checksum
      */
@@ -56,5 +56,21 @@ class Utils
         if ($index !== false) {
             unset($array[$index]);
         }
+    }
+
+    /**
+     * @return string
+     */
+    public static function getSourceApplication()
+    {
+        return 'PHP_SDK';
+    }
+
+    /**
+     * @return string
+     */
+    public static function getWebMasterID()
+    {
+        return PHP_VERSION;
     }
 }

--- a/tests/AlternativePaymentMethodTest.php
+++ b/tests/AlternativePaymentMethodTest.php
@@ -26,6 +26,7 @@ class AlternativePaymentMethodTest extends TestCase
      * @throws ConnectionException
      * @throws ResponseException
      * @throws ValidationException
+     * @run ./vendor/phpunit/phpunit/phpunit --filter testGetMerchantPaymentMethods ./tests/AlternativePaymentMethodTest.php
      */
     public function testGetMerchantPaymentMethods()
     {

--- a/tests/PaymentServiceTest.php
+++ b/tests/PaymentServiceTest.php
@@ -58,6 +58,7 @@ class PaymentServiceTest extends TestCase
      * @throws ConnectionException
      * @throws ResponseException
      * @throws ValidationException
+     * @run ./vendor/phpunit/phpunit/phpunit --filter testInitPayment ./tests/PaymentServiceTest.php
      */
     public function testInitPayment()
     {
@@ -277,6 +278,40 @@ class PaymentServiceTest extends TestCase
         ];
 
         $response = $this->service->getPaymentStatus($params);
+        $this->assertEquals('SUCCESS', $response['status']);
+    }
+
+    /**
+     * @throws Exception
+     * @throws ConnectionException
+     * @throws ResponseException
+     * @throws ValidationException
+     * @run ./vendor/phpunit/phpunit/phpunit --filter testAccountCapture ./tests/PaymentServiceTest.php
+     */
+    public function testAccountCapture()
+    {
+        $createPayment = $this->service->createPayment([
+            'currency'       => SimpleData::getCurrency(),
+            'amount'         => SimpleData::getAmount(),
+            'userTokenId'    => TestCaseHelper::getUserTokenId(),
+            'paymentOption'  => [
+                'card' => SimpleData::getCardData()
+            ],
+            'billingAddress' => SimpleData::getBillingAddress(),
+            'deviceDetails'  => SimpleData::getDeviceDetails()
+        ]);
+
+        $params = [
+            //'sessionToken'  => $createPayment['sessionToken'],
+            'userTokenId'       => TestCaseHelper::getUserTokenId(),
+            'paymentMethod'     => 'apmgw_Fast_Bank_Transfer',
+            'currencyCode'      => 'USD',
+            'countryCode'       => 'US',
+            'languageCode'      => 'en',
+            //'notificationUrl'   =>  ''
+        ];
+
+        $response = $this->service->accountCapture($params);
         $this->assertEquals('SUCCESS', $response['status']);
     }
 

--- a/tests/TestCaseHelper.php
+++ b/tests/TestCaseHelper.php
@@ -46,7 +46,8 @@ class TestCaseHelper
                 'merchantId'        => $config['merchantId'],
                 'merchantSiteId'    => $config['merchantSiteId'],
                 'merchantSecretKey' => $config['merchantSecretKey'],
-                'hashAlgorithm'     => $config['hashAlgorithm']
+                'hashAlgorithm'     => $config['hashAlgorithm'],
+                'debugMode'         => $config['debugMode'],
             ]);
 
             $logger = new Logger('safecharge-php-sdk');

--- a/tests/config.ini
+++ b/tests/config.ini
@@ -4,3 +4,4 @@ merchantId = '5078248497400694938'
 merchantSiteId = '142163'
 merchantSecretKey = 'F0EpuOTjZPIKw5SGcNGyISClL1zaVnArABS65EkfUIwVmzgNbEiiQeesGp4N79Rg'
 hashAlgorithm = 'sha256'
+debugMode = false


### PR DESCRIPTION
- Send two parameters with each call: "sourceApplication":"PHP_SDK"​ and "webMasterID":"<The version of the PHP>"
- New method /accountCapture
- Remove the ability to set the hash algorithm - MD5 is deprecated
- sessionToken should not be overridden - it will be forwarded to the rest of the calls. If a session expires - a new one will be created